### PR TITLE
Switch to hard-xml.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "hard-xml"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c049a5d5186e83c3cf139192e81ab9d06c6b20d18c8aa06b38f3f6a5ece8703"
+dependencies = [
+ "hard-xml-derive",
+ "jetscii",
+ "lazy_static",
+ "memchr",
+ "xmlparser",
+]
+
+[[package]]
+name = "hard-xml-derive"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24cec6f13bd2423158425bdb5f5ba0f2ddf7d7c2a825c0fdbf20c513df49725"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,8 +162,8 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 name = "opml"
 version = "1.1.3"
 dependencies = [
+ "hard-xml",
  "serde",
- "strong-xml",
  "thiserror",
 ]
 
@@ -240,30 +264,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "strong-xml"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d19fb3a618e2f1039e32317c9f525e6d45c55af704ec7c429aa74412419bebf"
-dependencies = [
- "jetscii",
- "lazy_static",
- "memchr",
- "strong-xml-derive",
- "xmlparser",
-]
-
-[[package]]
-name = "strong-xml-derive"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c781f499321613b112be5d9338189ef1ed19689a01edd23d923ea57ad5c7e1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/opml_api/Cargo.toml
+++ b/opml_api/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["xml", "opml"]
 path = "source/lib.rs"
 
 [dependencies]
-strong-xml = "0.6.3"
+hard-xml = "1.10.0"
 thiserror = "1.0.29"
 
 [dependencies.serde]

--- a/opml_api/source/lib.rs
+++ b/opml_api/source/lib.rs
@@ -30,7 +30,7 @@
 //! old `OPML { /* ... */ }` syntax.
 
 use serde::{Deserialize, Serialize};
-use strong_xml::{XmlRead, XmlWrite};
+use hard_xml::{XmlRead, XmlWrite};
 use thiserror::Error;
 
 /// All possible errors.
@@ -52,7 +52,7 @@ pub enum Error {
 
   /// The input string is not valid XML.
   #[error("Failed to process XML file")]
-  XmlError(#[from] strong_xml::XmlError),
+  XmlError(#[from] hard_xml::XmlError),
 }
 
 /// The top-level [`OPML`] element.

--- a/opml_api/tests/samples/empty_docs.opml
+++ b/opml_api/tests/samples/empty_docs.opml
@@ -1,0 +1,8 @@
+<opml version="2.0">
+  <head>
+    <docs />
+  </head>
+  <body>
+    <outline text="Outline Text"/>
+  </body>
+</opml>

--- a/opml_api/tests/valid.rs
+++ b/opml_api/tests/valid.rs
@@ -21,6 +21,29 @@ fn test_minimum_valid_opml() {
 }
 
 #[test]
+fn test_valid_empty_docs() {
+  assert_eq!(
+    OPML::from_str(
+      &read("tests/samples/empty_docs.opml").unwrap()
+    )
+    .unwrap(),
+    OPML {
+      version: "2.0".to_string(),
+      head: Some(Head {
+        docs: Some("".to_string()),
+         ..Head::default()
+      }),
+      body: Body {
+        outlines: vec![Outline {
+          text: "Outline Text".to_string(),
+          ..Outline::default()
+        }]
+      },
+    }
+  )
+}
+
+#[test]
 fn test_valid_opml_with_everything() {
   assert_eq!(
     OPML::from_str(


### PR DESCRIPTION
strong-xml is unmaintained and this fork includes a fix to a self-closing element causing a parse error.

This also fixes a build-time warning with the strong-xml derive macro.

Disclaimer: I am the maintainer of hard-xml, I forked it to fix this issue as it was affecting a project that I am working on. Originally [I submitted the patch to strong-xml](https://github.com/PoiScript/strong-xml/issues/35) but [the maintainer is inactive](https://github.com/PoiScript/strong-xml/issues/38) so I decided that in order to fix this problem with my project the fork was necessary.